### PR TITLE
Nissix plugin scope-packages on @wix/draft-js

### DIFF
--- a/examples/draft-0-10-0/playground/package.json
+++ b/examples/draft-0-10-0/playground/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "codemirror": "^5.32.0",
     "draft-convert": "^2.0.1",
-    "draft-js": "file:../../../",
+    "@wix/draft-js": "file:../../../",
     "immutable": "^3.8.2",
     "react": "^16.2.0",
     "react-codemirror2": "^3.0.7",

--- a/examples/draft-0-10-0/playground/src/App.js
+++ b/examples/draft-0-10-0/playground/src/App.js
@@ -11,14 +11,14 @@ import './DraftJsPlaygroundContainer.css';
 import {Controlled as CodeMirror} from 'react-codemirror2';
 import 'codemirror/lib/codemirror.css';
 import 'codemirror/mode/javascript/javascript';
-import 'draft-js/dist/Draft.css';
+import '@wix/draft-js/dist/Draft.css';
 import './App.css';
 import DraftJsRichEditorExample from './DraftJsRichEditorExample';
 import JSONTree from 'react-json-tree';
 import {convertToHTML} from 'draft-convert';
 import PanelGroup from 'react-panelgroup';
-import gkx from 'draft-js/lib/gkx';
-import convertFromHTMLModern from 'draft-js/lib/convertFromHTMLToContentBlocks2';
+import gkx from '@wix/draft-js/lib/gkx';
+import convertFromHTMLModern from '@wix/draft-js/lib/convertFromHTMLToContentBlocks2';
 
 import {
   ContentState,
@@ -26,7 +26,7 @@ import {
   convertFromHTML as convertFromHTMLClassic,
   convertToRaw,
   convertFromRaw,
-} from 'draft-js';
+} from '@wix/draft-js';
 
 const fromHTML = gkx('draft_refactored_html_importer')
   ? convertFromHTMLModern

--- a/examples/draft-0-10-0/playground/src/DraftJsRichEditorExample.js
+++ b/examples/draft-0-10-0/playground/src/DraftJsRichEditorExample.js
@@ -8,7 +8,7 @@
 
 import React, {Component} from 'react';
 
-import {Editor, RichUtils, getDefaultKeyBinding} from 'draft-js';
+import {Editor, RichUtils, getDefaultKeyBinding} from '@wix/draft-js';
 
 import './DraftJsRichEditorExample.css';
 

--- a/examples/draft-0-10-0/tex/js/components/TeXEditorExample.js
+++ b/examples/draft-0-10-0/tex/js/components/TeXEditorExample.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-import Draft from 'draft-js';
+import Draft from '@wix/draft-js';
 import {Map} from 'immutable';
 import React from 'react';
 

--- a/examples/draft-0-10-0/tex/js/data/content.js
+++ b/examples/draft-0-10-0/tex/js/data/content.js
@@ -12,7 +12,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import {convertFromRaw} from 'draft-js';
+import {convertFromRaw} from '@wix/draft-js';
 
 var rawContent = {
   blocks: [

--- a/examples/draft-0-10-0/tex/js/modifiers/insertTeXBlock.js
+++ b/examples/draft-0-10-0/tex/js/modifiers/insertTeXBlock.js
@@ -17,7 +17,7 @@
 import {
   AtomicBlockUtils,
   EditorState,
-} from 'draft-js';
+} from '@wix/draft-js';
 
 let count = 0;
 const examples = [

--- a/examples/draft-0-10-0/tex/js/modifiers/removeTeXBlock.js
+++ b/examples/draft-0-10-0/tex/js/modifiers/removeTeXBlock.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-import {EditorState, Modifier, SelectionState} from 'draft-js';
+import {EditorState, Modifier, SelectionState} from '@wix/draft-js';
 
 export function removeTeXBlock(editorState, blockKey) {
   var content = editorState.getCurrentContent();

--- a/examples/draft-0-10-0/tex/package.json
+++ b/examples/draft-0-10-0/tex/package.json
@@ -9,7 +9,7 @@
     "babel-loader": "^6.2.4",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.11.1",
-    "draft-js": "file:../../../",
+    "@wix/draft-js": "file:../../../",
     "express": "^4.13.1",
     "immutable": "^3.7.4",
     "katex": "^0.5.1",

--- a/examples/draft-0-10-0/tex/public/index.html
+++ b/examples/draft-0-10-0/tex/public/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <title>Draft • TeX</title>
     <link rel="stylesheet" href="TeXEditor.css" />
-    <link rel="stylesheet" href="node_modules/draft-js/dist/Draft.css" />
+    <link rel="stylesheet" href="node_modules/@wix/draft-js/dist/Draft.css" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.3.0/katex.min.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/es6-shim/0.34.4/es6-shim.min.js"></script>
   </head>

--- a/examples/draft-0-10-0/universal/editor.js
+++ b/examples/draft-0-10-0/universal/editor.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-const Draft = require('draft-js');
+const Draft = require('@wix/draft-js');
 const React = require('react');
 
 class SimpleEditor extends React.Component {

--- a/examples/draft-0-10-0/universal/package.json
+++ b/examples/draft-0-10-0/universal/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "draft-js": "file:../../../",
+    "@wix/draft-js": "file:../../../",
     "express": "^4.14.0",
     "immutable": "^3.8.1",
     "react": "^15.4.1",

--- a/examples/draft-0-9-1/tex/js/components/TeXBlock.js
+++ b/examples/draft-0-9-1/tex/js/components/TeXBlock.js
@@ -16,7 +16,7 @@
 
 import katex from 'katex';
 import React from 'react';
-import {Entity} from 'draft-js';
+import {Entity} from '@wix/draft-js';
 
 class KatexOutput extends React.Component {
   constructor(props) {

--- a/examples/draft-0-9-1/tex/js/components/TeXEditorExample.js
+++ b/examples/draft-0-9-1/tex/js/components/TeXEditorExample.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-import Draft from 'draft-js';
+import Draft from '@wix/draft-js';
 import {Map} from 'immutable';
 import React from 'react';
 

--- a/examples/draft-0-9-1/tex/js/data/content.js
+++ b/examples/draft-0-9-1/tex/js/data/content.js
@@ -12,7 +12,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import {convertFromRaw} from 'draft-js';
+import {convertFromRaw} from '@wix/draft-js';
 
 var rawContent = {
   blocks: [

--- a/examples/draft-0-9-1/tex/js/modifiers/insertTeXBlock.js
+++ b/examples/draft-0-9-1/tex/js/modifiers/insertTeXBlock.js
@@ -17,7 +17,7 @@
 import {
   AtomicBlockUtils,
   Entity,
-} from 'draft-js';
+} from '@wix/draft-js';
 
 let count = 0;
 const examples = [

--- a/examples/draft-0-9-1/tex/js/modifiers/removeTeXBlock.js
+++ b/examples/draft-0-9-1/tex/js/modifiers/removeTeXBlock.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-import {EditorState, Modifier, SelectionState} from 'draft-js';
+import {EditorState, Modifier, SelectionState} from '@wix/draft-js';
 
 export function removeTeXBlock(editorState, blockKey) {
   var content = editorState.getCurrentContent();

--- a/examples/draft-0-9-1/tex/package.json
+++ b/examples/draft-0-9-1/tex/package.json
@@ -9,7 +9,7 @@
     "babel-loader": "^6.2.4",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.11.1",
-    "draft-js": "file:../../../",
+    "@wix/draft-js": "file:../../../",
     "express": "^4.13.1",
     "immutable": "^3.7.4",
     "katex": "^0.5.1",

--- a/examples/draft-0-9-1/tex/public/index.html
+++ b/examples/draft-0-9-1/tex/public/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <title>Draft • TeX</title>
     <link rel="stylesheet" href="TeXEditor.css" />
-    <link rel="stylesheet" href="node_modules/draft-js/dist/Draft.css" />
+    <link rel="stylesheet" href="node_modules/@wix/draft-js/dist/Draft.css" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.3.0/katex.min.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/es6-shim/0.34.4/es6-shim.min.js"></script>
   </head>

--- a/examples/draft-0-9-1/universal/editor.js
+++ b/examples/draft-0-9-1/universal/editor.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-const Draft = require('draft-js');
+const Draft = require('@wix/draft-js');
 const React = require('react');
 
 class SimpleEditor extends React.Component {

--- a/examples/draft-0-9-1/universal/package.json
+++ b/examples/draft-0-9-1/universal/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "draft-js": "file:../../../",
+    "@wix/draft-js": "file:../../../",
     "express": "^4.14.0",
     "immutable": "^3.8.1",
     "react": "^15.4.1",

--- a/website/package.json
+++ b/website/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "compression": "1.2.2",
     "connect": "3.3.3",
-    "draft-js": "file:..",
+    "@wix/draft-js": "file:..",
     "errorhandler": "1.3.0",
     "fbjs": "^0.8.7",
     "fs.extra": "*",


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 8.38s
warning " > stats-webpack-plugin@0.6.2" has unmet peer dependency "webpack@>=1.0.0".
warning " > uglifyjs-webpack-plugin@1.1.6" has unmet peer dependency "webpack@^2.0.0 || ^3.0.0".
warning "uglifyjs-webpack-plugin > schema-utils@0.4.3" has unmet peer dependency "webpack@^2.0.0 || ^3.0.0".



Output Log:
Migrating package "@wix/draft-js" in .


## Migration from non scope to @wix/scoped packages
> /tmp/076222385418388c5ea5bdb6703728ba

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
website/package.json
examples/draft-0-10-0/playground/package.json
examples/draft-0-10-0/tex/package.json
examples/draft-0-10-0/universal/package.json
examples/draft-0-9-1/tex/package.json
examples/draft-0-9-1/universal/package.json
```

#### replace import/require in js/ts files
```
examples/draft-0-10-0/universal/editor.js
examples/draft-0-9-1/universal/editor.js
examples/draft-0-10-0/playground/src/App.js
examples/draft-0-10-0/playground/src/DraftJsRichEditorExample.js
examples/draft-0-10-0/tex/js/components/TeXEditorExample.js
examples/draft-0-10-0/tex/js/data/content.js
examples/draft-0-10-0/tex/js/modifiers/insertTeXBlock.js
examples/draft-0-10-0/tex/js/modifiers/removeTeXBlock.js
examples/draft-0-9-1/tex/js/components/TeXBlock.js
examples/draft-0-9-1/tex/js/components/TeXEditorExample.js
examples/draft-0-9-1/tex/js/data/content.js
examples/draft-0-9-1/tex/js/modifiers/insertTeXBlock.js
examples/draft-0-9-1/tex/js/modifiers/removeTeXBlock.js
```

#### replace unpkg & node_modules script tags in html and templates
```
examples/draft-0-10-0/tex/public/index.html
examples/draft-0-9-1/tex/public/index.html
```
yarn install v1.22.5
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@1.1.3: The platform "linux" is incompatible with this module.
info "fsevents@1.1.3" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
[4/4] Building fresh packages...
Done in 11.31s.

