### PR TITLE
Nissix plugin scope-packages on playground

### DIFF
--- a/examples/draft-0-10-0/playground/package.json
+++ b/examples/draft-0-10-0/playground/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "codemirror": "^5.32.0",
     "draft-convert": "^2.0.1",
-    "draft-js": "file:../../../",
+    "@wix/draft-js": "file:../../../",
     "immutable": "^3.8.2",
     "react": "^16.2.0",
     "react-codemirror2": "^3.0.7",

--- a/examples/draft-0-10-0/playground/src/App.js
+++ b/examples/draft-0-10-0/playground/src/App.js
@@ -11,14 +11,14 @@ import './DraftJsPlaygroundContainer.css';
 import {Controlled as CodeMirror} from 'react-codemirror2';
 import 'codemirror/lib/codemirror.css';
 import 'codemirror/mode/javascript/javascript';
-import 'draft-js/dist/Draft.css';
+import '@wix/draft-js/dist/Draft.css';
 import './App.css';
 import DraftJsRichEditorExample from './DraftJsRichEditorExample';
 import JSONTree from 'react-json-tree';
 import {convertToHTML} from 'draft-convert';
 import PanelGroup from 'react-panelgroup';
-import gkx from 'draft-js/lib/gkx';
-import convertFromHTMLModern from 'draft-js/lib/convertFromHTMLToContentBlocks2';
+import gkx from '@wix/draft-js/lib/gkx';
+import convertFromHTMLModern from '@wix/draft-js/lib/convertFromHTMLToContentBlocks2';
 
 import {
   ContentState,
@@ -26,7 +26,7 @@ import {
   convertFromHTML as convertFromHTMLClassic,
   convertToRaw,
   convertFromRaw,
-} from 'draft-js';
+} from '@wix/draft-js';
 
 const fromHTML = gkx('draft_refactored_html_importer')
   ? convertFromHTMLModern

--- a/examples/draft-0-10-0/playground/src/DraftJsRichEditorExample.js
+++ b/examples/draft-0-10-0/playground/src/DraftJsRichEditorExample.js
@@ -8,7 +8,7 @@
 
 import React, {Component} from 'react';
 
-import {Editor, RichUtils, getDefaultKeyBinding} from 'draft-js';
+import {Editor, RichUtils, getDefaultKeyBinding} from '@wix/draft-js';
 
 import './DraftJsRichEditorExample.css';
 

--- a/examples/draft-0-10-0/playground/yarn.lock
+++ b/examples/draft-0-10-0/playground/yarn.lock
@@ -2,6 +2,14 @@
 # yarn lockfile v1
 
 
+"@wix/draft-js@file:../../..":
+  version "0.10.5"
+  dependencies:
+    fbjs "^0.8.15"
+    immutable "~3.7.4"
+    object-assign "^4.1.0"
+    wnpm-ci "^6.2.54"
+
 abab@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
@@ -122,6 +130,11 @@ ansi-styles@^3.0.0, ansi-styles@^3.1.0:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
   dependencies:
     color-convert "^1.9.0"
+
+any-promise@^1.0.0:
+  version "1.3.0"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
+  integrity sha1-q8av7tzqUugJzcA3au0845Y10X8=
 
 anymatch@^1.3.0:
   version "1.3.2"
@@ -1944,13 +1957,6 @@ draft-convert@^2.0.1:
   dependencies:
     immutable "~3.7.4"
     invariant "^2.2.1"
-
-"draft-js@file:../../../":
-  version "0.10.4"
-  dependencies:
-    fbjs "^0.8.15"
-    immutable "~3.7.4"
-    object-assign "^4.1.0"
 
 duplexer2@^0.1.4:
   version "0.1.4"
@@ -5621,6 +5627,11 @@ shell-quote@1.6.1:
     array-reduce "~0.0.0"
     jsonify "~0.0.0"
 
+shelljs@^0.5.3:
+  version "0.5.3"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/shelljs/-/shelljs-0.5.3.tgz#c54982b996c76ef0c1e6b59fbdc5825f5b713113"
+  integrity sha1-xUmCuZbHbvDB5rWfvcWCX1txMRM=
+
 shellwords@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
@@ -5966,6 +5977,13 @@ test-exclude@^4.1.1:
 text-table@0.2.0, text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
+
+thenify@^3.2.0:
+  version "3.3.1"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/thenify/-/thenify-3.3.1.tgz#8932e686a4066038a016dd9e2ca46add9838a95f"
+  integrity sha1-iTLmhqQGYDigFt2eLKRq3Zg4qV8=
+  dependencies:
+    any-promise "^1.0.0"
 
 throat@^3.0.0:
   version "3.2.0"
@@ -6421,6 +6439,14 @@ widest-line@^1.0.0:
 window-size@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
+
+wnpm-ci@^6.2.54:
+  version "6.2.55"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/wnpm-ci/-/wnpm-ci-6.2.55.tgz#636967f5df9d87373427f79bbfff7052267c4405"
+  integrity sha1-Y2ln9d+dhzc0J/ebv/9wUiZ8RAU=
+  dependencies:
+    shelljs "^0.5.3"
+    thenify "^3.2.0"
 
 wordwrap@0.0.2, wordwrap@~0.0.2:
   version "0.0.2"


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 9.586s
warning " > draft-convert@2.0.1" has unmet peer dependency "draft-js@>=0.7.0".



Output Log:
Migrating package "playground" in examples/draft-0-10-0/playground


## Migration from non scope to @wix/scoped packages
> /tmp/b984a9036dd65a52fb5d05b21652901e/examples/draft-0-10-0/playground

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```

#### replace import/require in js/ts files
```
src/App.js
src/DraftJsRichEditorExample.js
```
yarn install v1.22.5
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@1.1.2: The platform "linux" is incompatible with this module.
info "fsevents@1.1.2" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
Done in 14.58s.

