### PR TITLE
Nissix plugin scope-packages

### DIFF
--- a/examples/draft-0-10-0/tex/js/components/TeXEditorExample.js
+++ b/examples/draft-0-10-0/tex/js/components/TeXEditorExample.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-import Draft from 'draft-js';
+import Draft from '@wix/draft-js';
 import {Map} from 'immutable';
 import React from 'react';
 

--- a/examples/draft-0-10-0/tex/js/data/content.js
+++ b/examples/draft-0-10-0/tex/js/data/content.js
@@ -12,7 +12,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import {convertFromRaw} from 'draft-js';
+import {convertFromRaw} from '@wix/draft-js';
 
 var rawContent = {
   blocks: [

--- a/examples/draft-0-10-0/tex/js/modifiers/insertTeXBlock.js
+++ b/examples/draft-0-10-0/tex/js/modifiers/insertTeXBlock.js
@@ -17,7 +17,7 @@
 import {
   AtomicBlockUtils,
   EditorState,
-} from 'draft-js';
+} from '@wix/draft-js';
 
 let count = 0;
 const examples = [

--- a/examples/draft-0-10-0/tex/js/modifiers/removeTeXBlock.js
+++ b/examples/draft-0-10-0/tex/js/modifiers/removeTeXBlock.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-import {EditorState, Modifier, SelectionState} from 'draft-js';
+import {EditorState, Modifier, SelectionState} from '@wix/draft-js';
 
 export function removeTeXBlock(editorState, blockKey) {
   var content = editorState.getCurrentContent();

--- a/examples/draft-0-10-0/tex/package.json
+++ b/examples/draft-0-10-0/tex/package.json
@@ -9,7 +9,7 @@
     "babel-loader": "^6.2.4",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.11.1",
-    "draft-js": "file:../../../",
+    "@wix/draft-js": "file:../../../",
     "express": "^4.13.1",
     "immutable": "^3.7.4",
     "katex": "^0.5.1",

--- a/examples/draft-0-10-0/tex/public/index.html
+++ b/examples/draft-0-10-0/tex/public/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <title>Draft • TeX</title>
     <link rel="stylesheet" href="TeXEditor.css" />
-    <link rel="stylesheet" href="node_modules/draft-js/dist/Draft.css" />
+    <link rel="stylesheet" href="node_modules/@wix/draft-js/dist/Draft.css" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.3.0/katex.min.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/es6-shim/0.34.4/es6-shim.min.js"></script>
   </head>

--- a/examples/draft-0-10-0/tex/yarn.lock
+++ b/examples/draft-0-10-0/tex/yarn.lock
@@ -2,6 +2,14 @@
 # yarn lockfile v1
 
 
+"@wix/draft-js@file:../../..":
+  version "0.10.5"
+  dependencies:
+    fbjs "^0.8.15"
+    immutable "~3.7.4"
+    object-assign "^4.1.0"
+    wnpm-ci "^6.2.54"
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -53,6 +61,11 @@ ansi-regex@^2.0.0:
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
+
+any-promise@^1.0.0:
+  version "1.3.0"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
+  integrity sha1-q8av7tzqUugJzcA3au0845Y10X8=
 
 anymatch@^1.3.0:
   version "1.3.2"
@@ -1170,13 +1183,6 @@ detective@^4.3.1:
 domain-browser@^1.1.1:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.1.7.tgz#867aa4b093faa05f1de08c06f4d7b21fdf8698bc"
-
-"draft-js@file:../../..":
-  version "0.10.4"
-  dependencies:
-    fbjs "^0.8.15"
-    immutable "~3.7.4"
-    object-assign "^4.1.0"
 
 ecc-jsbn@~0.1.1:
   version "0.1.1"
@@ -2625,6 +2631,11 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
+shelljs@^0.5.3:
+  version "0.5.3"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/shelljs/-/shelljs-0.5.3.tgz#c54982b996c76ef0c1e6b59fbdc5825f5b713113"
+  integrity sha1-xUmCuZbHbvDB5rWfvcWCX1txMRM=
+
 signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
@@ -2818,6 +2829,13 @@ tar@^2.2.1:
     block-stream "*"
     fstream "^1.0.2"
     inherits "2"
+
+thenify@^3.2.0:
+  version "3.3.1"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/thenify/-/thenify-3.3.1.tgz#8932e686a4066038a016dd9e2ca46add9838a95f"
+  integrity sha1-iTLmhqQGYDigFt2eLKRq3Zg4qV8=
+  dependencies:
+    any-promise "^1.0.0"
 
 through@~2.3.8:
   version "2.3.8"
@@ -3063,6 +3081,14 @@ window-size@0.1.0:
 window-size@^0.1.2:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.4.tgz#f8e1aa1ee5a53ec5bf151ffa09742a6ad7697876"
+
+wnpm-ci@^6.2.54:
+  version "6.2.55"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/wnpm-ci/-/wnpm-ci-6.2.55.tgz#636967f5df9d87373427f79bbfff7052267c4405"
+  integrity sha1-Y2ln9d+dhzc0J/ebv/9wUiZ8RAU=
+  dependencies:
+    shelljs "^0.5.3"
+    thenify "^3.2.0"
 
 wordwrap@0.0.2:
   version "0.0.2"


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 9.812s



Output Log:
Migrating package "undefined" in examples/draft-0-10-0/tex


## Migration from non scope to @wix/scoped packages
> /tmp/5d205b3aa201ee7cf1012c360eb3659d/examples/draft-0-10-0/tex

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```

#### replace import/require in js/ts files
```
js/components/TeXEditorExample.js
js/data/content.js
js/modifiers/insertTeXBlock.js
js/modifiers/removeTeXBlock.js
```

#### replace unpkg & node_modules script tags in html and templates
```
public/index.html
```
yarn install v1.22.5
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@1.1.3: The platform "linux" is incompatible with this module.
info "fsevents@1.1.3" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
Done in 13.86s.

