### PR TITLE
Nissix plugin scope-packages on universal

### DIFF
--- a/examples/draft-0-9-1/universal/editor.js
+++ b/examples/draft-0-9-1/universal/editor.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-const Draft = require('draft-js');
+const Draft = require('@wix/draft-js');
 const React = require('react');
 
 class SimpleEditor extends React.Component {

--- a/examples/draft-0-9-1/universal/package.json
+++ b/examples/draft-0-9-1/universal/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "draft-js": "file:../../../",
+    "@wix/draft-js": "file:../../../",
     "express": "^4.14.0",
     "immutable": "^3.8.1",
     "react": "^15.4.1",


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 9.875s



Output Log:
Migrating package "universal" in examples/draft-0-10-0/universal


## Migration from non scope to @wix/scoped packages
> /tmp/2986d595cc9c1e6f5e0ac0ec3e3de252/examples/draft-0-10-0/universal

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```

#### replace import/require in js/ts files
```
editor.js
```

